### PR TITLE
Add docs that the codemod defaults to RTL act usage by default

### DIFF
--- a/.changeset/fresh-zoos-deliver.md
+++ b/.changeset/fresh-zoos-deliver.md
@@ -1,0 +1,5 @@
+---
+"codemod-missing-await-act": minor
+---
+
+Add APIs from React Testing Library

--- a/README.md
+++ b/README.md
@@ -45,8 +45,14 @@ For example, this codemod will not add an `await` to `someObj.cleanup()`.
 
 ```bash
 $ npx codemod-missing-await-act ./src
-
-TODO
+Processing 4 files... 
+All done. 
+Results: 
+0 errors
+3 unmodified
+0 skipped
+1 ok
+Time elapsed: 0.428seconds 
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ For example, this codemod will not add an `await` to `someObj.cleanup()`.
 
 ```bash
 $ npx codemod-missing-await-act ./src
-Processing 4 files... 
-All done. 
-Results: 
+Processing 4 files...
+All done.
+Results:
 0 errors
 3 unmodified
 0 skipped
 1 ok
-Time elapsed: 0.428seconds 
+Time elapsed: 0.428seconds
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,45 @@
 # codemod-missing-await-act
 
-Adds missing `await` using [jscodeshift](https://github.com/facebook/jscodeshift)
+Adds missing `await` to `act` calls or methods that like contain an `act` call using [jscodeshift](https://github.com/facebook/jscodeshift).
+We all track usage of these methods throughout the file.
+For example, given
+
+```tsx
+function focus(element) {
+	act(() => {
+		element.focus();
+	});
+}
+
+test("focusing", () => {
+	const { container } = render("<button />");
+
+	focus(container);
+});
+```
+
+will add an `await` to `act` and also add `await` to `focus` since `focus` is now an async method.
+The end result will be
+
+```tsx
+async function focus(element) {
+	await act(() => {
+		element.focus();
+	});
+}
+
+test("focusing", async () => {
+	const { container } = await render("<button />");
+
+	await focus(container);
+});
+```
+
+Right now we assume calls to `act`, `render`, `rerender`, `fireEvent` and `cleanup` should be awaited.
+These are all names of methods from React Testing Library.
+
+Note that any call expression that calls a method from an object (so called "member expression") are not codemodded.
+For example, this codemod will not add an `await` to `someObj.cleanup()`.
 
 ## Getting started
 

--- a/transforms/__tests__/codemod-missing-await-act.js
+++ b/transforms/__tests__/codemod-missing-await-act.js
@@ -133,44 +133,60 @@ test("act in utils #3", () => {
 test("React Testing Library api", () => {
 	expect(
 		applyTransform(`
-			import { cleanup, fireEvent, render } from "@testing-library/react";
+			import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 			beforeEach(() => {
 				cleanup();
 			});
-
-			function renderWithProviders(element) {
-				const {rerender, unmount} = render(<TestProvider>{element}</TestProvider>);
 			
-				return {rerender, unmount}
+			function renderWithProviders(element) {
+				const { rerender, unmount } = render(<TestProvider>{element}</TestProvider>);
+			
+				return { rerender, unmount };
 			}
 			
 			test("test", () => {
-				const { rerender, unmount } = renderWithProviders(<div />);
+				const { rerender, unmount } = renderWithProviders(<button>Test</button>);
+			
+				fireEvent.click(screen.getByRole("button"));
 			
 				rerender(<span />);
 			
+				fireEvent(
+					screen.getByRole("button"),
+					new MouseEvent("click", {
+						bubbles: true,
+						cancelable: true,
+					})
+				);
+			
 				unmount();
 			});
-		
 		`)
 	).toMatchInlineSnapshot(`
-		"import { cleanup, fireEvent, render } from "@testing-library/react";
+		"import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 		beforeEach(async () => {
 			await cleanup();
 		});
 
 		async function renderWithProviders(element) {
-			const {rerender, unmount} = await render(<TestProvider>{element}</TestProvider>);
+			const { rerender, unmount } = await render(<TestProvider>{element}</TestProvider>);
 
-			return {rerender, unmount}
+			return { rerender, unmount };
 		}
 
 		test("test", async () => {
-			const { rerender, unmount } = await renderWithProviders(<div />);
+			const { rerender, unmount } = await renderWithProviders(<button>Test</button>);
+
+			await fireEvent.click(screen.getByRole("button"));
 
 			await rerender(<span />);
+
+			await fireEvent(screen.getByRole("button"), new MouseEvent("click", {
+		        bubbles: true,
+		        cancelable: true,
+		    }));
 
 			await unmount();
 		});"

--- a/transforms/__tests__/codemod-missing-await-act.js
+++ b/transforms/__tests__/codemod-missing-await-act.js
@@ -8,7 +8,7 @@ function applyTransform(source, options = {}) {
 		codemodMissingAwaitTransform,
 		options,
 		{
-			path: "test.ts",
+			path: "test.tsx",
 			source: dedent(source),
 		}
 	);
@@ -127,5 +127,52 @@ test("act in utils #3", () => {
 			
 			return test
 		}"
+	`);
+});
+
+test("React Testing Library api", () => {
+	expect(
+		applyTransform(`
+			import { cleanup, fireEvent, render } from "@testing-library/react";
+
+			beforeEach(() => {
+				cleanup();
+			});
+
+			function renderWithProviders(element) {
+				const {rerender, unmount} = render(<TestProvider>{element}</TestProvider>);
+			
+				return {rerender, unmount}
+			}
+			
+			test("test", () => {
+				const { rerender, unmount } = renderWithProviders(<div />);
+			
+				rerender(<span />);
+			
+				unmount();
+			});
+		
+		`)
+	).toMatchInlineSnapshot(`
+		"import { cleanup, fireEvent, render } from "@testing-library/react";
+
+		beforeEach(async () => {
+			await cleanup();
+		});
+
+		async function renderWithProviders(element) {
+			const {rerender, unmount} = await render(<TestProvider>{element}</TestProvider>);
+
+			return {rerender, unmount}
+		}
+
+		test("test", async () => {
+			const { rerender, unmount } = await renderWithProviders(<div />);
+
+			await rerender(<span />);
+
+			await unmount();
+		});"
 	`);
 });

--- a/transforms/codemod-missing-await-act.js
+++ b/transforms/codemod-missing-await-act.js
@@ -58,7 +58,6 @@ function isActOrCallsAct(callExpression) {
 		return true;
 	}
 
-
 	// render
 	if (
 		callExpression.callee.type === "Identifier" &&

--- a/transforms/codemod-missing-await-act.js
+++ b/transforms/codemod-missing-await-act.js
@@ -50,6 +50,15 @@ function isActOrCallsAct(callExpression) {
 		return true;
 	}
 
+	// fireEvent()
+	if (
+		callExpression.callee.type === "Identifier" &&
+		callExpression.callee.name === "fireEvent"
+	) {
+		return true;
+	}
+
+
 	// render
 	if (
 		callExpression.callee.type === "Identifier" &&


### PR DESCRIPTION
`act`, `render`, `rerender`, `unmount` and `cleanup` will be transformed.