### PR TITLE
Fix parse errors when codemodding files containing JSX

### DIFF
--- a/.changeset/empty-worms-sort.md
+++ b/.changeset/empty-worms-sort.md
@@ -1,0 +1,5 @@
+---
+"codemod-missing-await-act": patch
+---
+
+Fix parse errors when transform files containing JSX

--- a/bin/codemod-missing-await-act.cjs
+++ b/bin/codemod-missing-await-act.cjs
@@ -51,7 +51,7 @@ async function main() {
 				 * @type {string[]}
 				 */
 				const args = [
-					"--extensions=tsx,ts",
+					"--extensions=js,jsx,mjs,cjs,ts,tsx,mts,cts",
 					`"--ignore-pattern=${argv.ignorePattern}"`,
 					// The transforms are published as JS compatible with the supported Node.js versions.
 					"--no-babel",

--- a/transforms/utils/__tests__/parseSync.js
+++ b/transforms/utils/__tests__/parseSync.js
@@ -20,4 +20,22 @@ describe("parseSync", () => {
 			})
 		).not.toThrow();
 	});
+
+	test("tsx", () => {
+		expect(() =>
+			parseSync({
+				path: "test.tsx",
+				source: `<div />`,
+			})
+		).not.toThrow();
+	});
+
+	test("jsx", () => {
+		expect(() =>
+			parseSync({
+				path: "test.js",
+				source: `<div />`,
+			})
+		).not.toThrow();
+	});
 });

--- a/transforms/utils/parseSync.js
+++ b/transforms/utils/parseSync.js
@@ -48,13 +48,24 @@ const tsxParserOptions = {
 	...tsParserOptions,
 	plugins: [...tsParserOptions.plugins, "jsx"],
 };
+const jsParserOptions = {
+	...baseParserOptions,
+	plugins: [...baseParserOptions.plugins, "jsx"],
+};
 
 /**
  * Fork `jscodeshift`'s `tsx` parser with support for .d.ts files
  * @param {import('jscodeshift').FileInfo} fileInfo
  */
 function parseSync(fileInfo) {
-	const dts = fileInfo.path.endsWith(".d.ts");
+	const ts =
+		fileInfo.path.endsWith(".ts") ||
+		fileInfo.path.endsWith(".mts") ||
+		fileInfo.path.endsWith(".cts");
+	const dts =
+		fileInfo.path.endsWith(".d.ts") ||
+		fileInfo.path.endsWith(".d.mts") ||
+		fileInfo.path.endsWith(".d.cts");
 	const tsx = fileInfo.path.endsWith(".tsx");
 
 	return j(fileInfo.source, {
@@ -73,10 +84,12 @@ function parseSync(fileInfo) {
 						// So if the parser fails in an ambient context we just try again without ambient context
 					}
 				}
-				if (tsx) {
+				if (ts) {
+					return babylon.parse(code, tsParserOptions);
+				} else if (tsx) {
 					return babylon.parse(code, tsxParserOptions);
 				} else {
-					return babylon.parse(code, tsParserOptions);
+					return babylon.parse(code, jsParserOptions);
 				}
 			},
 		},


### PR DESCRIPTION
Source was copied from codemod only targetting TS. Now we properly parse JS files under the assumption they contain JSX.