### PR TITLE
Stop codemodding declaration files

### DIFF
--- a/.changeset/bright-moles-wash.md
+++ b/.changeset/bright-moles-wash.md
@@ -1,0 +1,5 @@
+---
+"codemod-missing-await-act": patch
+---
+
+Stop codemodding declaration files

--- a/transforms/codemod-missing-await-act.js
+++ b/transforms/codemod-missing-await-act.js
@@ -132,6 +132,15 @@ function isActOrCallsAct(callee, importSource) {
  * Summary for Klarna's klapp@TODO
  */
 const codemodMissingAwaitActTransform = (file) => {
+	// Ideally we'd not match these earlier but it seems easier to bail out here.
+	const isDeclarationFile =
+		file.path.endsWith(".d.ts") || file.path.endsWith(".d.cts");
+	file.path.endsWith(".d.ts") || file.path.endsWith(".d.mts");
+	if (isDeclarationFile) {
+		// undefined return marks the file as skipped in JSCodeShift (nice!)
+		return;
+	}
+
 	const ast = parseSync(file);
 	/** @type {Set<string>} */
 	const warnedExports = new Set();


### PR DESCRIPTION
They were just incidentally included since they also match `.ts`.