### PR TITLE
fix: Ensure multiple import configs can be used during module lifetime

### DIFF
--- a/.changeset/chilled-houses-beg.md
+++ b/.changeset/chilled-houses-beg.md
@@ -1,0 +1,5 @@
+---
+"codemod-missing-await-act": patch
+---
+
+Ensure different import configs can be used during module lifetime

--- a/transforms/__tests__/codemod-missing-await-act.js
+++ b/transforms/__tests__/codemod-missing-await-act.js
@@ -675,7 +675,7 @@ test("export newly async reassignment does not warn", async () => {
 	await expect(console.warn.mock.calls).toEqual([]);
 });
 
-test.only("import config with default export", async () => {
+test("import config with default export", async () => {
 	await expect(
 		applyTransform(
 			`


### PR DESCRIPTION
No impact on CLI. Only programmatic use.

We used to cache the import config once. That meant that calling the transform repeatedly with different configs would ignore ignore configs from subsequent calls. 