### PR TITLE
Add support for propagating through relative paths

### DIFF
--- a/.changeset/little-dogs-sparkle.md
+++ b/.changeset/little-dogs-sparkle.md
@@ -1,0 +1,17 @@
+---
+"codemod-missing-await-act": minor
+---
+
+Add support for propagating through relative paths
+
+The import config (from `--import-config-path`) can now contain imports to absolute
+paths prefixed as file URLs.
+File URLs will be matched against relative imports.
+Given this import config
+
+```js
+import { render as render1 } from "file:///root/relative-paths/utils.js";
+```
+
+the import `import { render } from './utils'` in `/root/index.test.js` will be
+considered as newly async and each call of `render` will be awaited.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,11 +12,18 @@ module.exports = {
 	rules: {},
 	overrides: [
 		{
-			files: ["default-import-config.js"],
+			files: [
+				"default-import-config.js",
+				"bin/__tests__/__fixtures__/**/import-config.js",
+			],
 			parserOptions: { sourceType: "module" },
 			rules: {
 				"no-unused-vars": "off",
 			},
+		},
+		{
+			files: ["bin/__tests__/__fixtures__/**"],
+			parserOptions: { sourceType: "module" },
 		},
 	],
 };

--- a/bin/__tests__/__fixtures__/relative-paths/README.md
+++ b/bin/__tests__/__fixtures__/relative-paths/README.md
@@ -1,0 +1,36 @@
+```bash
+$ yarn test:manual-fixture bin/__tests__/__fixtures__/relative-paths --import-config import-config.js
+
+4 unmodified
+0 skipped
+2 ok
+Time elapsed: 0.256seconds
+diff --git a/bin/__tests__/__fixtures__/relative-paths/foo/another-test.js b/bin/__tests__/__fixtures__/relative-paths/foo/another-test.js
+index 0e8c648..cddf6b5 100644
+--- a/bin/__tests__/__fixtures__/relative-paths/foo/another-test.js
++++ b/bin/__tests__/__fixtures__/relative-paths/foo/another-test.js
+@@ -1,7 +1,7 @@
+ import { render } from "../utils.js";
+
+-test("should render", () => {
+-       render();
++test("should render", async () => {
++       await render();
+ });
+
+ function test(description, fn) {
+diff --git a/bin/__tests__/__fixtures__/relative-paths/some-test.js b/bin/__tests__/__fixtures__/relative-paths/some-test.js
+index 450092c..c5e241a 100644
+--- a/bin/__tests__/__fixtures__/relative-paths/some-test.js
++++ b/bin/__tests__/__fixtures__/relative-paths/some-test.js
+@@ -1,7 +1,7 @@
+ import { render } from "./utils";
+
+-test("should render", () => {
+-       render();
++test("should render", async () => {
++       await render();
+ });
+
+ function test(description, fn) {
+```

--- a/bin/__tests__/__fixtures__/relative-paths/foo/another-test.js
+++ b/bin/__tests__/__fixtures__/relative-paths/foo/another-test.js
@@ -1,0 +1,9 @@
+import { render } from "../utils.js";
+
+test("should render", () => {
+	render();
+});
+
+function test(description, fn) {
+	fn();
+}

--- a/bin/__tests__/__fixtures__/relative-paths/foo/untouched-import-test.js
+++ b/bin/__tests__/__fixtures__/relative-paths/foo/untouched-import-test.js
@@ -1,0 +1,9 @@
+import { render } from "./utils.js";
+
+test("should render", () => {
+	render();
+});
+
+function test(description, fn) {
+	fn();
+}

--- a/bin/__tests__/__fixtures__/relative-paths/foo/utils.js
+++ b/bin/__tests__/__fixtures__/relative-paths/foo/utils.js
@@ -1,0 +1,5 @@
+export function render() {
+	// sync render that stays sync.
+	// Purposefully ambiguous to test the resolver.
+	// Now we have ~/utils.js (async render) and ~/foo/utils.js (sync render).
+}

--- a/bin/__tests__/__fixtures__/relative-paths/import-config.js
+++ b/bin/__tests__/__fixtures__/relative-paths/import-config.js
@@ -1,0 +1,1 @@
+import { render as render1 } from "file:///Users/sebbie/repos/codemod-missing-await-act/bin/__tests__/__fixtures__/relative-paths/utils.js";

--- a/bin/__tests__/__fixtures__/relative-paths/some-test.js
+++ b/bin/__tests__/__fixtures__/relative-paths/some-test.js
@@ -1,0 +1,9 @@
+import { render } from "./utils";
+
+test("should render", () => {
+	render();
+});
+
+function test(description, fn) {
+	fn();
+}

--- a/bin/__tests__/__fixtures__/relative-paths/utils.js
+++ b/bin/__tests__/__fixtures__/relative-paths/utils.js
@@ -1,0 +1,5 @@
+import { render as rtlRender } from "@testing-library/react";
+
+export function render() {
+	rtlRender();
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"format:check": "prettier . --check",
 		"release": "yarn changeset publish",
 		"test:lint": "eslint bin/**/*.{cjs,js,mjs} transforms/**/*.{cjs,js,mjs}",
+		"test:manual-fixture": "./scripts/test-manual-fixture.sh",
 		"test:renovate": "npx --package renovate@31.21.2 -c renovate-config-validator",
 		"test:types": "tsc -p tsconfig.json --noEmit",
 		"test:unit": "jest"

--- a/scripts/test-manual-fixture.sh
+++ b/scripts/test-manual-fixture.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Simple test runner for upgrade fixtures.
+# For manual verification only (check the README.md) in the fixtures
+# for the expected behavior.
+# Usage:
+# - cwd must repo root
+# - `yarn test:manual-fixture <fixture-name> <...codemod-args>`
+
+CODEMOD_BIN=$(pwd)/bin/codemod-missing-await-act.cjs
+cd "$1" || exit 1
+# We're only interested in the changes the upgrade command does.
+git add -A .
+node "$CODEMOD_BIN" . "${@:2}"
+git --no-pager diff .
+git restore .
+git reset --quiet HEAD -- .


### PR DESCRIPTION
The import config (from `--import-config-path`) can now contain imports to absolute
paths prefixed as file URLs.
File URLs will be matched against relative imports.
Given this import config

```js
import { render as render1 } from "file:///root/relative-paths/utils.js";
```

the import `import { render } from './utils'` in `/root/index.test.js` will be
considered as newly async and each call of `render` will be awaited.