### PR TITLE
Summarize follow-up items when codemod finished

### DIFF
--- a/.changeset/shiny-horses-tan.md
+++ b/.changeset/shiny-horses-tan.md
@@ -1,0 +1,13 @@
+---
+"codemod-missing-await-act": minor
+---
+
+Summarize follow-up items when codemod finished
+
+When newly async functions are exported, the codemod will not automatically update
+all references.
+However, we now summarize at the end which files are impacted and generate an import
+config that can be used to update the remaining references if these are imported
+via relative imports.
+However, if these exports are imported via package specifiers or other path aliases,
+users need to manually adjust the import sources which is explained in the README.

--- a/bin/__tests__/__fixtures__/follow-up-import-config/README.md
+++ b/bin/__tests__/__fixtures__/follow-up-import-config/README.md
@@ -1,0 +1,23 @@
+```bash
+$ yarn test:manual-fixture bin/__tests__/__fixtures__/relative-paths
+Make sure to update import config to include the following files and their exports.
+utils.js:
+  - render
+An import config considering the above files was generated in <NEW_IMPORT_CONFIG> . If these files are not necessarily imported as relative paths, you should add additional entries to the import config as explained in https://github.com/eps1lon/codemod-missing-await-act#custom-import-config.
+After you adjusted above import config accordingly, run the codemod again with
+`--import-config <NEW_IMPORT_CONFIG>`
+```
+
+`<NEW_IMPORT_CONFIG>` should contain
+
+```js
+import { render as render1 } from "file:///Users/sebbie/repos/codemod-missing-await-act/bin/__tests__/__fixtures__/relative-paths/utils.js";
+```
+
+Ultimately, starting with
+
+```js
+import { render as render1 } from "@testing-library/react";
+```
+
+in `bin/__tests__/__fixtures__/relative-paths/import-config.js` and then following the iterative approach, should result in the original, final result.

--- a/bin/__tests__/__fixtures__/follow-up-import-config/utils.js
+++ b/bin/__tests__/__fixtures__/follow-up-import-config/utils.js
@@ -1,0 +1,5 @@
+import { render as rtlRender } from "@testing-library/react";
+
+export function render() {
+	rtlRender();
+}


### PR DESCRIPTION
When newly async functions are exported, the codemod will not automatically update
all references.
However, we now summarize at the end which files are impacted and generate an import
config that can be used to update the remaining references if these are imported
via relative imports.
However, if these exports are imported via package specifiers or other path aliases,
users need to manually adjust the import sources which is explained in the README.