### PR TITLE
add `explicitResourceManagement` plugin

### DIFF
--- a/transforms/utils/parseSync.js
+++ b/transforms/utils/parseSync.js
@@ -34,6 +34,7 @@ const baseParserOptions = {
 		"optionalChaining",
 		["pipelineOperator", { proposal: "minimal" }],
 		"throwExpressions",
+		"explicitResourceManagement",
 	],
 };
 


### PR DESCRIPTION
We use `using` a lot in our tests, so this is necessary to apply the codemod to them.