### PR TITLE
Log escaped bindings even if code wasn't changed  

### DIFF
--- a/.changeset/sour-avocados-shave.md
+++ b/.changeset/sour-avocados-shave.md
@@ -1,0 +1,9 @@
+---
+"codemod-missing-await-act": patch
+---
+
+Log escaped bindings even if code wasn't changed
+
+E.g. `export const myAct = scope => React.act(scope)` is newly async,
+but we didn't used to log it because the code didn't change.
+Now we do log it as escaped and recommend running the codemod again.

--- a/transforms/__tests__/codemod-missing-await-act.js
+++ b/transforms/__tests__/codemod-missing-await-act.js
@@ -762,5 +762,16 @@ test("missing scope await", async () => {
 		code,
 	);
 	const escapedBindingsFiles = await fs.readdir(escapedBindingsPath);
-	expect(escapedBindingsFiles).toHaveLength(0);
+	expect(escapedBindingsFiles).toHaveLength(1);
+	await expect(
+		fs
+			.readFile(
+				path.join(escapedBindingsPath, escapedBindingsFiles[0]),
+				"utf-8",
+			)
+			.then((json) => JSON.parse(json)),
+	).resolves.toEqual({
+		escapedBindings: ["typedNewlyAsync", "untypedNewlyAsync", "alwaysAsync"],
+		filePath: expect.any(String),
+	});
 });


### PR DESCRIPTION
E.g. `export const myAct = scope => React.act(scope)` is newly async,
but we didn't used to log it because the code didn't change.
Now we do log it as escaped and recommend running the codemod again.