### PR TITLE
[ci] Fix Renovate config validation job

### DIFF
--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -2,8 +2,11 @@ name: Validate Renovate config
 
 on:
   push:
-    # run everytime on main to catch conflicting merges
-    branches: [main]
+    branches:
+      # run everytime on main to catch conflicting merges
+      - main
+      # hardcoded test branch to test this workflow
+      - test/ci-validate-renovate
   pull_request:
     branches: [main]
     paths: [".github/renovate.json"]
@@ -19,4 +22,5 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
-      - run: yarn test:renovate
+      # keep in sync with `yarn test:renovate`
+      - run: yarn dlx --package renovate@31.21.2 renovate-config-validator

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"release": "yarn changeset publish",
 		"test:lint": "eslint bin/**/*.{cjs,js,mjs} transforms/**/*.{cjs,js,mjs}",
 		"test:manual-fixture": "./scripts/test-manual-fixture.sh",
-		"test:renovate": "npx --package renovate@31.21.2 -c renovate-config-validator",
+		"test:renovate": "yarn dlx --package renovate@31.21.2 renovate-config-validator",
 		"test:types": "tsc -p tsconfig.json --noEmit",
 		"test:unit": "jest"
 	},


### PR DESCRIPTION
Fixes 
```
Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)
```
-- https://github.com/eps1lon/codemod-missing-await-act/actions/runs/12997567856/job/36248836108#step:4:5

Seems like you can't run Yarn scripts without install even if those scripts don't have any dependencies.